### PR TITLE
Remove the default value for device_id

### DIFF
--- a/config.py
+++ b/config.py
@@ -64,7 +64,7 @@ class Config(object):
         if not self.device_id:
             logger.warning(
                 "Config option matrix.device_id is not provided, which means "
-                " encryption won't work correctly"
+                "that end-to-end encryption won't work correctly"
             )
 
         self.homeserver_url = matrix.get("homeserver_url")

--- a/config.py
+++ b/config.py
@@ -63,7 +63,7 @@ class Config(object):
         self.device_id = matrix.get("device_id")
         if not self.device_id:
             logger.warning(
-                "matrix.device_id is not provided, which means that end-to-end
+                "matrix.device_id is not provided, which means that end-to-end"
                 " encryption won't work correctly"
             )
 

--- a/config.py
+++ b/config.py
@@ -63,7 +63,7 @@ class Config(object):
         self.device_id = matrix.get("device_id")
         if not self.device_id:
             logger.warning(
-                "matrix.device_id is not provided, which means that end-to-end"
+                "Config option matrix.device_id is not provided, which means "
                 " encryption won't work correctly"
             )
 

--- a/config.py
+++ b/config.py
@@ -60,7 +60,12 @@ class Config(object):
         if not self.access_token:
             raise ConfigError("matrix.access_token is a required field")
 
-        self.device_id = matrix.get("device_id", "cribbage bot")
+        self.device_id = matrix.get("device_id")
+        if not self.device_id:
+            logger.warning(
+                "matrix.device_id is not provided, which means that end-to-end
+                " encryption won't work correctly"
+            )
 
         self.homeserver_url = matrix.get("homeserver_url")
         if not self.homeserver_url:


### PR DESCRIPTION
nio doesn't need a device_id unless E2EE is used, so the correct behaviour should be to default it to `None` and, if it's missing, warn the user of what might happen.