### PR TITLE
Remove unneeded key_upload

### DIFF
--- a/my_project_name/main.py
+++ b/my_project_name/main.py
@@ -82,11 +82,6 @@ async def main():
 
             # Login succeeded!
 
-            # Sync encryption keys with the server
-            # Required for participating in encrypted rooms
-            if client.should_upload_keys:
-                await client.keys_upload()
-
             logger.info(f"Logged in as {config.user_id}")
             await client.sync_forever(timeout=30000, full_state=True)
 


### PR DESCRIPTION
It is automatically called by `sync_forever()`.
See https://matrix-nio.readthedocs.io/en/latest/nio.html?highlight=keys_upload#nio.AsyncClient.keys_upload