### PR TITLE
Allow config items to really be required=False

### DIFF
--- a/my_project_name/config.py
+++ b/my_project_name/config.py
@@ -112,7 +112,7 @@ class Config(object):
             # If at any point we don't get our expected option...
             if config is None:
                 # Raise an error if it was required
-                if required or not default:
+                if required and not default:
                     raise ConfigError(f"Config option {'.'.join(path)} is required")
 
                 # or return the default value


### PR DESCRIPTION
In the case of `required or not default` with default defaulting to `None` it's impossible to have a `required=False` config item, without supplying a default

To make `required=False` actually mean "you don't need to specify this at all", it needs to be `required and not default` when checking if we should raise `ConfigError`.

Unless I misunderstand the intention of `required` and `default` :)