### PR TITLE
Enable logging in using an access token

### DIFF
--- a/my_project_name/config.py
+++ b/my_project_name/config.py
@@ -85,7 +85,11 @@ class Config(object):
         if not re.match("@.*:.*", self.user_id):
             raise ConfigError("matrix.user_id must be in the form @name:domain")
 
-        self.user_password = self._get_cfg(["matrix", "user_password"], required=True)
+        self.user_password = self._get_cfg(["matrix", "user_password"], required=False)
+        self.user_token = self._get_cfg(["matrix", "user_token"], required=False)
+        if not self.user_token and not self.user_password:
+            raise ConfigError("Must supply either user token or password")
+
         self.device_id = self._get_cfg(["matrix", "device_id"], required=True)
         self.device_name = self._get_cfg(
             ["matrix", "device_name"], default="nio-template"

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -9,8 +9,10 @@ command_prefix: "!c"
 matrix:
   # The Matrix User ID of the bot account
   user_id: "@bot:example.com"
-  # Matrix account password
+  # Matrix account password (optional if access token used)
   user_password: ""
+  # Matrix account access token (optional if password used)
+  #user_token: ""
   # The URL of the homeserver to connect to
   homeserver_url: https://example.com
   # The device ID that is **non pre-existing** device


### PR DESCRIPTION
We do a `client.load_store()` to restore a previous session.

If both token and password are defined, token is preferred, since it wont create a new device for the bot. One or the other needs to be defined.

Requires https://github.com/anoadragon453/nio-template/pull/20 for the configuration change since password and access token must both be optional (but one must be given).