### PR TITLE
Skip InviteMemberEvents that are not our invites

### DIFF
--- a/my_project_name/main.py
+++ b/my_project_name/main.py
@@ -71,11 +71,11 @@ async def main():
         """
         Since the InviteMemberEvent is fired for every m.room.member state received
         in a sync response's `rooms.invite` section, we will receive some that are
-        not actually our own invite event.
+        not actually our own invite event (such as the inviter's membership).
         This makes sure we only call `callbacks.invite` with our own invite events.
         """
         if event.state_key == client.user_id:
-            # This is not our own membership (invite) event
+            # This is our own membership (invite) event
             callbacks.invite(room, event)
 
     client.add_event_callback(invite_event_filtered_callback, (InviteMemberEvent,))


### PR DESCRIPTION
Was conflicted about putting this check inside `callbacks.invite` itself or as a wrapper (like I did here).

Went for the wrapper because it seemed 'right' to protect the `Callbacks` class from unfortunate callback flaws.