### PR TITLE
Only set HTML format if markdown is used

### DIFF
--- a/my_project_name/chat_functions.py
+++ b/my_project_name/chat_functions.py
@@ -49,11 +49,11 @@ async def send_text_to_room(
 
     content = {
         "msgtype": msgtype,
-        "format": "org.matrix.custom.html",
         "body": message,
     }
 
     if markdown_convert:
+        content["format"] = "org.matrix.custom.html"
         content["formatted_body"] = markdown(message)
 
     if reply_to_event_id:


### PR DESCRIPTION
Recently ran into an issue where plaintext messages were not rendering on the Element IOS client.

This is because all HTML messages need to have a `formatted_body` to adhere to the [Matrix spec](https://spec.matrix.org/v1.4/client-server-api/#mroommessage-msgtypes).